### PR TITLE
remove ^\images$

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,7 +4,6 @@
 ^\.travis\.yml$
 ^README\.Rmd$
 ^LICENSE\.md$
-^\images$
 ^\docs$
 docs
 img


### PR DESCRIPTION
This is intended to address #76 - it looks like this line in `.Rbuildignore` was causing the issue:

`^\images$`

I _think_ but am not sure that removing this is okay, as the `images` directory is still ignored by another line in `.Rbuildignore`.